### PR TITLE
Skip cleanup for empty iterations

### DIFF
--- a/code/KustoCopyConsole/Runner/IterationManagementRunner.cs
+++ b/code/KustoCopyConsole/Runner/IterationManagementRunner.cs
@@ -164,7 +164,14 @@ namespace KustoCopyConsole.Runner
 
         private async Task CleanTempTableAsync(IterationRecord iteration, CancellationToken ct)
         {
-            var tempTable = GetTempTable(iteration.IterationKey);
+            var tempTable = TryGetTempTable(iteration.IterationKey);
+
+            if (tempTable == null)
+            {
+                //  Empty iterations have no temp table to clean up.
+                return;
+            }
+
             var destinationTable = Parameterization
                 .GetActivity(iteration.IterationKey.ActivityName)
                 .GetDestinationTableIdentity();


### PR DESCRIPTION
Closes #112.

Empty iterations (no extents to copy) never run through `TempTableCreatingRunner`, so there's no `TempTableRecord` in `Created` state for them. The strict `GetTempTable` lookup in `CleanTempTableAsync` then throws and the kc process exits with a permanent error.

Swap it for the existing `TryGetTempTable` and return early when there's nothing to drop. Both helpers already exist on `RunnerBase`.

Unblocks long-running `BackfillAndNew` workloads where most iterations are no-ops between source extent arrivals. Happy to add a regression test if you can point at the right place. Didn't see an existing test for this runner.